### PR TITLE
weston: correct koelsch weston.ini

### DIFF
--- a/meta-genivi-dev/recipes-graphics/wayland/weston/koelsch/weston.ini
+++ b/meta-genivi-dev/recipes-graphics/wayland/weston/koelsch/weston.ini
@@ -3,6 +3,7 @@ shell=ivi-shell.so
 
 [ivi-shell]
 ivi-module=ivi-controller.so
+ivi-input-module=ivi-input-controller.so
 transition-duration=300
 cursor-theme=default
 


### PR DESCRIPTION
When the maintainers updated to Wayland 1.9.0 and the equivalent IVI-Extension in commit 4f3a052ef7d5d they forgot to update the weston.ini for the Renesas R-Car M2 Koelsch Evaluation board as well. Correct that omission by making the change now.
